### PR TITLE
Bump version of Hibernate Validator

### DIFF
--- a/easysourcing/pom.xml
+++ b/easysourcing/pom.xml
@@ -122,12 +122,12 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.1.5.Final</version>
+            <version>6.2.4.Final</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator-annotation-processor</artifactId>
-            <version>6.1.5.Final</version>
+            <version>6.2.4.Final</version>
         </dependency>
         <dependency>
             <groupId>javax.el</groupId>


### PR DESCRIPTION
Bump version of Hibernate Validator so that you can use both EasySourcing and Java 17 records